### PR TITLE
Agents and Targets utilize unique ids now.

### DIFF
--- a/summer21/json2csds/Agent.py
+++ b/summer21/json2csds/Agent.py
@@ -60,7 +60,7 @@ class AgentCollection:
         :return: None.
         """
         # Add the new agent instance to the collection, indeed using the object's ID to put the object in a dict.
-        self.agent_instances[new_instance.id] = new_instance
+        self.agent_instances[new_instance.unique_id] = new_instance
 
     def get_instance(self, instance_id):
         """
@@ -80,7 +80,7 @@ class AgentCollection:
         Returns the list of Agent objects.
         :return: A list of Agent objects.
         """
-        return self.agent_instances.values()
+        return self.agent_instances
 
     def get_num_instances(self):
         """

--- a/summer21/json2csds/Target.py
+++ b/summer21/json2csds/Target.py
@@ -53,7 +53,7 @@ class eTarget(Target):
         The init method (constructor) for eTarget class.
         """
         Target.__init__(self, this_text, this_id, this_head_start, this_head_end, this_annotation_type,
-                        this_head, this_sentence_id, unique_id=-1)
+                        this_head, this_sentence_id, unique_id)
         self.type_etarget = this_type_etarget
         self.is_negated = this_is_negated
         self.is_referred_in_span = this_is_referred_in_span
@@ -73,7 +73,7 @@ class sTarget(Target):
         The init method (constructor) for sTarget class.
         """
         Target.__init__(self, this_text, this_id, this_head_start, this_head_end, this_annotation_type,
-                        this_head, this_sentence_id, unique_id=-1)
+                        this_head, this_sentence_id, unique_id)
         self.target_uncertain = this_target_uncertain
         self.etarget_link = this_etarget_link
 
@@ -107,7 +107,7 @@ class TargetCollection:
         :return: None.
         """
         # Add the new Target instance to the collection, indeed using the object's ID to put the object in a dict.
-        self.target_instances[new_instance.target_id] = new_instance
+        self.target_instances[new_instance.unique_id] = new_instance
 
     def get_instance(self, instance_id):
         """
@@ -128,7 +128,7 @@ class TargetCollection:
         Returns the list of Target objects.
         :return: A list of Target objects.
         """
-        return self.target_instances.values()
+        return self.target_instances
 
     def get_num_instances(self):
         """

--- a/summer21/json2csds/json2csds_code_segment.py
+++ b/summer21/json2csds/json2csds_code_segment.py
@@ -16,9 +16,9 @@ with open(path + 'data_mpqa.json', 'w', encoding='utf-8') as f:
     json.dump(mpqa_json, f, ensure_ascii=False, indent=4)
 
 
-with open(path + 'dataV2.json', 'w', encoding='utf-8') as f:
+with open(path + 'dataV3.json', 'w', encoding='utf-8') as f:
     json.dump(json_output, f, ensure_ascii=False, indent=4)
 
 # Loading the saved JSON file.
-with open(path + 'dataV2.json') as json_file:
+with open(path + 'dataV3.json') as json_file:
     data = json.load(json_file)

--- a/summer21/mpqa_dataprocessing/mpqa2_to_dict.py
+++ b/summer21/mpqa_dataprocessing/mpqa2_to_dict.py
@@ -9,7 +9,7 @@ import re
 
 HAS_LIST_OF_IDS = [ # These attributes may have any number of ids. (>= 0)
     "nested-source", "attitude-link", "insubstantial",
-    "target-speech-link"
+    "target-speech-link", "target-link"
 ]
 
 class mpqa2_to_dict:
@@ -113,7 +113,7 @@ class mpqa2_to_dict:
                     key, val = key.strip(), val.strip()
                     val = val[1:-1] # Removes double quotation marks
                     if key in HAS_LIST_OF_IDS:
-                        temp_dict[key] = [] if val == "none" else val.split(',')
+                        temp_dict[key] = [] if val == "none" or val == "" else [v.strip() for v in val.split(',')]
                     else:
                         temp_dict[key] = val
 

--- a/summer21/mpqa_dataprocessing/mpqa3_to_dict.py
+++ b/summer21/mpqa_dataprocessing/mpqa3_to_dict.py
@@ -99,7 +99,7 @@ class mpqa3_to_dict:
                 key, val = key.strip(), val.strip()
                 val = val[1:-1] # Removes double quotation marks
                 if key in HAS_LIST_OF_IDS:
-                    temp_dict[key] = [] if val == "none" else val.split(',')
+                    temp_dict[key] = [] if val == "none" or val == "" else  [v.strip() for v in val.split(',')]
                 else:
                     temp_dict[key] = val
             # We probably know the identifier assigned to the annotation by now


### PR DESCRIPTION
mpqa2_to_dict considers target-links as lists now.
All target and agent links are replaced with their unique ids.
agent_objects and target_objects in the output JSON file are dictionaries.